### PR TITLE
Make programmers.txt snippet compatible with platforms that use pluggable discovery syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Example OTA 'programmer' configuration in programmers.txt:
 ```
 arduinoOTA104.name=Arduino OTA (192.168.1.104)
 arduinoOTA104.program.tool=arduinoOTA
+arduinoOTA104.program.default=arduinoOTA
 arduinoOTA104.ip=192.168.1.104
 ``` 
 


### PR DESCRIPTION
A new flexible and powerful ["pluggable discovery" system](https://arduino.github.io/arduino-cli/0.27/platform-specification/#pluggable-discovery) was added to the Arduino boards platform framework. This system makes it easy for Arduino boards platform authors to use any arbitrary communication channel between the board and development tools.

Boards platform configurations that use the old property syntax are automatically translated to the new syntax by Arduino CLI.

https://arduino.github.io/arduino-cli/latest/platform-specification/#sketch-upload-configuration

This translation is only done in platforms that use the old syntax exclusively. If `pluggable_discovery` properties are defined for the platform then the new pluggable discovery-style [`program.tool.<protocol_name>` properties](https://arduino.github.io/arduino-cli/latest/platform-specification/#upload-using-an-external-programmer) must be defined as well. If not, the "**Upload Using Programmer**" operation will fail:

```text
Property 'program.tool.serial' is undefined
```

Or if no serial port is selected:

```text
Property 'program.tool.' is undefined
```

Since the `programmers.txt` snippet provided in the readme is intended to be used with any platform, it must be compatible with those that use the new pluggable discovery syntax (e.g., https://github.com/arduino/ArduinoCore-samd/pull/648). This is accomplished by adding an `arduinoOTA115.program.tool.default` property.

It is also important to provide compatibility with older versions of Arduino development tools. For this reason, the old style property `arduinoOTA115.program.tool` is retained. Old versions of the development tools will treat the `arduinoOTA115.program.tool.default` property as an arbitrary user defined property with no special significance and the new versions of the development tools will do the same for the `arduinoOTA115.program.tool` property.