### PR TITLE
Define `NO_OTA_NETWORK` to disable all network-related functionality

### DIFF
--- a/src/ArduinoOTA.h
+++ b/src/ArduinoOTA.h
@@ -19,7 +19,10 @@
 #ifndef _ARDUINOOTA_H_
 #define _ARDUINOOTA_H_
 
+#if !defined(NO_OTA_NETWORK)
 #include "WiFiOTA.h"
+#endif
+
 #ifdef __AVR__
 #if FLASHEND >= 0xFFFF
 #include "InternalStorageAVR.h"
@@ -109,7 +112,9 @@ public:
 
 };
 
-#if defined(ethernet_h_) || defined(ethernet_h) // Ethernet library
+#if defined(NO_OTA_NETWORK)
+// Disable network libraries
+#elif defined(ethernet_h_) || defined(ethernet_h) // Ethernet library
 #ifdef NO_OTA_PORT
 ArduinoOTAClass  <EthernetServer, EthernetClient>   ArduinoOTA;
 #else

--- a/src/WiFiOTA.cpp
+++ b/src/WiFiOTA.cpp
@@ -21,6 +21,8 @@
  by Juraj Andrassy
 */
 
+#if !defined(NO_OTA_NETWORK)
+
 #include <Arduino.h>
 
 #include "WiFiOTA.h"
@@ -369,4 +371,6 @@ void WiFiOTAClass::flushRequestBody(Client& client, long contentLength)
     }
   }
 }
+
+#endif // NO_OTA_NETWORK
 


### PR DESCRIPTION
I've developed a custom firmware delivery mechanism (i.e. using a cellular or packet radio connection on a ESP32), so I'd like to disable the built-in implementation.