### PR TITLE
Fix mDNS not working when using handle() and not poll()

### DIFF
--- a/src/ArduinoOTA.h
+++ b/src/ArduinoOTA.h
@@ -108,6 +108,10 @@ public:
     WiFiOTAClass::pollMdns(mdnsSocket);
   }
 
+  void handle() { // alias
+    poll();
+  }
+
 };
 
 #if defined(NO_OTA_NETWORK)


### PR DESCRIPTION
As there was no override to the handle() function on the ArduinoOTAMdnsClass class then the base class function was called and it didnt handle the mDNS functionality.