### PR TITLE
Make ArduinoOTA definitions `extern` in header

### DIFF
--- a/src/ArduinoOTA.cpp
+++ b/src/ArduinoOTA.cpp
@@ -1,0 +1,18 @@
+#include "ArduinoOTA.h"
+
+#ifdef OTETHERNET
+#ifdef NO_OTA_PORT
+ArduinoOTAClass  <EthernetServer, EthernetClient>   ArduinoOTA;
+#else
+ArduinoOTAMdnsClass  <EthernetServer, EthernetClient, EthernetUDP>   ArduinoOTA;
+#endif
+
+#else
+
+#ifdef NO_OTA_PORT
+ArduinoOTAClass  <WiFiServer, WiFiClient> ArduinoOTA;
+#else
+#include <WiFiUdp.h>
+ArduinoOTAMdnsClass <WiFiServer, WiFiClient, WiFiUDP> ArduinoOTA;
+#endif
+#endif

--- a/src/ArduinoOTA.h
+++ b/src/ArduinoOTA.h
@@ -127,18 +127,18 @@ public:
 
 #ifdef OTETHERNET
 #ifdef NO_OTA_PORT
-ArduinoOTAClass  <EthernetServer, EthernetClient>   ArduinoOTA;
+extern ArduinoOTAClass  <EthernetServer, EthernetClient>   ArduinoOTA;
 #else
-ArduinoOTAMdnsClass  <EthernetServer, EthernetClient, EthernetUDP>   ArduinoOTA;
+extern ArduinoOTAMdnsClass  <EthernetServer, EthernetClient, EthernetUDP>   ArduinoOTA;
 #endif
 
 #else
 
 #ifdef NO_OTA_PORT
-ArduinoOTAClass  <WiFiServer, WiFiClient> ArduinoOTA;
+extern ArduinoOTAClass  <WiFiServer, WiFiClient> ArduinoOTA;
 #else
 #include <WiFiUdp.h>
-ArduinoOTAMdnsClass <WiFiServer, WiFiClient, WiFiUDP> ArduinoOTA;
+extern ArduinoOTAMdnsClass <WiFiServer, WiFiClient, WiFiUDP> ArduinoOTA;
 #endif
 #endif
 


### PR DESCRIPTION
Having the definitions be non-`extern` meant that the header couldn't be included by multiple files at once.

This patch fixes the problem but may not be the best choice for a solution - perhaps a singleton would be better fit? It may be a better design choice but will cause an API break.