### PR TITLE
fix(rp2040): remove CMSIS RP2040.h to fix macro redefinition warnings

### DIFF
--- a/src/utility/rp2_flash_boot.c
+++ b/src/utility/rp2_flash_boot.c
@@ -22,7 +22,7 @@
 
 #include <hardware/flash.h>
 #include <pico/bootrom.h>
-#include <RP2040.h> // CMSIS
+#include <hardware/watchdog.h>
 #include <hardware/structs/ssi.h> // XIP_BASE defintion
 
 // boot2 functions copied from hardware/flash.c
@@ -90,7 +90,7 @@ void __no_inline_not_in_flash_func(copy_flash_pages)(uint32_t flash_offs, const 
       count -= FLASH_PAGE_SIZE;
     }
     if (reset) {
-      NVIC_SystemReset();
+      watchdog_reboot(0, 0, 0);
     }
 }
 


### PR DESCRIPTION
## Summary

On arduino-pico core 4.x+, `rp2_flash_boot.c` produces ~30 macro redefinition warnings because it includes `<RP2040.h>` (CMSIS) which redefines base address constants already defined by the pico-sdk's `addressmap.h`.

The only symbol used from `RP2040.h` was `NVIC_SystemReset()`. This PR replaces it with `watchdog_reboot()` from `<hardware/watchdog.h>` (pico-sdk), consistent with the approach taken in OTAStorage.cpp in v1.1.1.

## Changes

- `src/utility/rp2_flash_boot.c`: Replace `#include <RP2040.h>` with `#include <hardware/watchdog.h>`, and `NVIC_SystemReset()` with `watchdog_reboot(0, 0, 0)`

## Test plan

- Compiled and tested with arduino-pico core 5.5.1 + Ethernet_Generic 2.8.1 on RP2040 (W5500 wired Ethernet with OTA)
- Warnings eliminated, OTA functionality preserved